### PR TITLE
docs: add system documentation

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -1,0 +1,112 @@
+# Agent Guide
+
+How to work with Ren, Forge, and Vex.
+
+---
+
+## Ren (Main Agent)
+
+**Role:** Planner, orchestrator, George's main interface.
+
+Ren is who George talks to. She reads everything, makes decisions, and coordinates Forge and Vex. She also does research, manages calendar/email on George's behalf, runs cron jobs, and handles strategic planning.
+
+**What George says to Ren:**
+- Natural language requests: "Build me X", "What's on my calendar?", "Research Y"
+- High-level direction: Ren figures out the details
+- Approval decisions: Ren will ask "should I proceed?" for anything with real-world consequences
+
+**Workspace:** `/home/georges/.openclaw/workspace/`
+
+**Discord:** `Ren AI` — `@1481802596443357196`
+
+---
+
+## Forge (Builder Agent)
+
+**Role:** Implementation — code, PRs, TDD, CI. Does not initiate conversations with George.
+
+Forge picks up tasks from GitHub Issues and builds them. He follows TDD, opens PRs, and pings Vex. He does not respond to general conversation in Discord. He only acts when Ren assigns a task.
+
+**How to get Forge to build something:**
+1. Tell Ren what you want
+2. Ren creates a GitHub Issue with full spec
+3. Ren pings `@Forge AI` with the issue link
+4. Forge builds and opens a PR
+
+**When Forge goes quiet:** That's correct behavior. He's idle until Ren assigns a task.
+
+**Workspace:** `/home/georges/.openclaw/workspace-forge/`
+
+**Discord:** `Forge AI` — `@1481893856633950248`
+
+---
+
+## Vex (QA Gate)
+
+**Role:** Hard gate on every PR. Pass or fail — no redesign, no suggestions beyond what blocks the merge.
+
+Vex reviews PRs after Forge opens them. Her verdict is binary: ✅ PASS (clear for merge) or ❌ BLOCKED (with specific fix). When blocked, the fix goes to Ren — who relays it to Forge. Vex does not respond to general conversation.
+
+**What Vex checks:**
+- Stage 1 (spec compliance): Do ACs from the issue match what's in the PR?
+- Stage 2 (code quality): Tests pass? No debug artifacts? No out-of-scope changes?
+
+**Workspace:** `/home/georges/.openclaw/workspace-vex/`
+
+**Discord:** `Vex AI` — `@1482113890610446449`
+
+---
+
+## Coordination Protocol
+
+The crew follows a hub-and-spoke model where Ren is the hub:
+
+```
+George → Ren → Forge → Vex → Ren → George
+```
+
+1. **George** tells Ren what to do
+2. **Ren** creates a GitHub Issue and pings `@Forge AI` with the task
+3. **Forge** builds, opens a PR, posts "PR #N up" in Discord (for visibility only)
+4. **Ren** pings `@Vex AI` to gate the PR
+5. **Vex** posts gate result addressed to `@Ren AI` — then stands down
+6. **Ren** relays to Forge: "PASS — merging" or "BLOCKED — [specific fix]"
+7. **Forge** acts only on Ren's relay
+
+**Key rules:**
+- Forge does not respond to Vex's Discord messages directly
+- Vex does not respond to Forge's Discord messages or George's messages
+- When Forge has contradictory data, he states it once and waits for Ren to adjudicate
+- `memory/active-tasks.md` shows who owns what — check before touching a task
+
+---
+
+## Who Talks to Whom
+
+| Conversation | How |
+|---|---|
+| George → crew | Discord `#fish-tank`, natural language to Ren |
+| Ren → Forge | Discord `@Forge AI` mention + GitHub Issue link |
+| Ren → Vex | Discord `@Vex AI` mention + PR link |
+| Forge → Ren | PR comment + brief Discord post |
+| Vex → Ren | Discord gate result addressed to `@Ren AI` |
+| Ren → George | Discord `#fish-tank`, plain language |
+
+---
+
+## PR Lifecycle
+
+```
+GitHub Issue (spec) 
+  → Forge branch (feat/<slug> or fix/<slug>)
+    → PR opened (Closes #N in body)
+      → Vex gate (PASS or BLOCKED)
+        → Ren pre-review
+          → George merges (or Ren for eligible PRs)
+```
+
+**Auto-merge eligible (no George required):**
+- `dungeon-cards` PRs after Vex PASS + Ren pre-review
+- George explicitly granted this for game dev
+
+**All other repos:** George merges.

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -1,0 +1,114 @@
+# System Overview
+
+This document describes the hardware, software, and agent setup running on George's Raspberry Pi 5.
+
+---
+
+## Hardware
+
+**Primary machine:** Raspberry Pi 5 (8GB RAM, 4-core ARM Cortex-A76, ~117GB storage)
+- Running 24/7 at home
+- Connected via Tailscale VPN at `100.122.117.128`
+- Connected to Discord via bot tokens for all three agents
+
+**Secondary machine (available):** Raspberry Pi 3 Model B v1.2 (1GB RAM)
+- Not currently in active use
+
+---
+
+## Software Stack
+
+### OpenClaw
+OpenClaw is the agent hosting platform. It runs on the Pi and manages:
+- Agent sessions (Ren, Forge, Vex)
+- Discord channel routing (inbound/outbound messages)
+- Cron jobs for autonomous tasks
+- Memory file management
+- Tool access (web search, exec, file I/O)
+
+Config: `/home/georges/.openclaw/openclaw.json`
+
+### Agents
+
+Three agents run on the Pi, each with their own workspace:
+
+| Agent | Role | Workspace | Discord |
+|---|---|---|---|
+| **Ren** (main) | Planner, orchestrator, George's main interface | `/home/georges/.openclaw/workspace/` | Ren AI |
+| **Forge** | Builder — code, PRs, TDD | `/home/georges/.openclaw/workspace-forge/` | Forge AI |
+| **Vex** | QA gate — reviews PRs, hard pass/fail | `/home/georges/.openclaw/workspace-vex/` | Vex AI |
+
+All agents communicate through the `#fish-tank` Discord channel.
+
+### Channel
+- **Discord guild:** Fish Tank
+- **Channel:** `#fish-tank` (ID: `1481915397966921789`)
+- George (Shrill) reads and participates here; Ren leads all conversations with George
+
+---
+
+## GitHub Setup
+
+Two GitHub organizations:
+
+| Org | Purpose | Access |
+|---|---|---|
+| `gasoto-ai` | Original org; portfolio + workflow live here | PAT in `/home/georges/.openclaw/workspace-forge/credentials.md` |
+| `gasoto-dev` | Primary active org for all new projects | PAT in `/home/georges/.openclaw/workspace/credentials.md` |
+
+**Note:** Both orgs are active. Migration to gasoto-dev as sole primary is in the ClickUp backlog.
+
+### Active repos on gasoto-dev
+- `checkout-demo` — Stripe e-commerce demo
+- `webhook-inspector` — Live webhook debugger
+- `agent-monitor` — Multi-agent activity dashboard
+- `kelly-soto-photography` — Kelly Soto photography site
+- `dashboard` — Team metrics dashboard (runs on Pi)
+- `dungeon-cards` — Godot 4 roguelike deckbuilder
+- `bomb-burritos` — Bomb Burritos LLC web site
+- `bomb-burritos-app` — Bomb Burritos React Native app
+
+### Active repos on gasoto-ai
+- `portfolio` — George Soto's portfolio (live at codeyoursuccess.com)
+- `workflow` — This repo; methodology + skill docs
+- `the-crate`, `fish-tank-tools`, `codelens` — Earlier demo apps
+
+---
+
+## Memory System (L0/L1/L2)
+
+Each agent maintains tiered memory:
+
+**L0 — `memory/state.md`** (loaded every session)
+Current project status, open tasks, active repos, auth notes. Both agents use this.
+
+**L1 — `MEMORY.md`** (Ren only, main sessions with George)
+Curated long-term memory: decisions, lessons, George context. Not loaded in group chats.
+
+**L2 — `memory/projects/<repo>.md`** (loaded when working on that repo)
+Per-repo context: stack, routes, DB schema, test setup, gotchas.
+
+**Daily logs:** `memory/YYYY-MM-DD.md` — raw session notes, never deleted.
+
+**Active task ownership:** `memory/active-tasks.md` — who owns what right now; prevents coordination conflicts.
+
+---
+
+## Autonomous Crons
+
+| Schedule | Task |
+|---|---|
+| Daily 9am MST | Ren runs daily research |
+| Monday 10am MST | Vex runs weekly repo audit |
+| Friday afternoon MST | Ren posts weekly digest |
+
+---
+
+## Deployed Apps
+
+| App | URL | Host |
+|---|---|---|
+| Portfolio | `codeyoursuccess.com` | Vercel |
+| Dashboard | `http://100.122.117.128:3002` | Pi (Tailscale only) |
+
+Other apps (checkout-demo, webhook-inspector, agent-monitor, bomb-burritos) are built but not yet deployed to Vercel.

--- a/docs/workflow-guide.md
+++ b/docs/workflow-guide.md
@@ -1,0 +1,156 @@
+# Workflow Guide
+
+How tasks move through the system, from George's request to shipped code.
+
+---
+
+## Full Task Lifecycle
+
+```
+1. George approves idea (or asks for something)
+2. Ren creates GitHub Issue (spec, ACs, branch name)
+3. Ren pings @Forge AI with issue link
+4. Forge reads issue, comments "On it. Branch: <branch>"
+5. Forge builds on feature branch (TDD: test → implement → pass → commit)
+6. Forge opens PR (branch → main, body: "Closes #N")
+7. Forge posts "PR #N up" in Discord
+8. Ren pings @Vex AI with PR link
+9. Vex reviews (Stage 1: spec compliance → Stage 2: code quality)
+10. Vex posts result to @Ren AI
+11. Ren relays to Forge: PASS → merge, or BLOCKED → specific fix
+12. If BLOCKED: Forge fixes, updates PR, loop back to step 8
+13. If PASS: Ren pre-reviews, then merges or escalates to George
+14. George merges (or auto-merge for dungeon-cards)
+```
+
+---
+
+## GitHub Issues as the Source of Truth
+
+Every task starts with a GitHub Issue. No code before an issue.
+
+**Issue structure:**
+```markdown
+## Context
+Why this exists.
+
+## Acceptance Criteria
+- [ ] Specific, testable outcomes
+- [ ] One per line
+
+## Files likely affected
+- Which files change
+
+## Out of scope
+- What we're NOT doing
+```
+
+**Issue location:**
+- `gasoto-ai/workflow` — methodology, process, system docs
+- `gasoto-dev/<repo>` — code changes to that repo
+
+---
+
+## Branch Naming
+
+| Type | Convention | Example |
+|---|---|---|
+| Feature | `feat/<slug>` | `feat/stripe-checkout` |
+| Bug fix | `fix/<slug>` | `fix/cart-quantity-bug` |
+| Chore | `chore/<slug>` | `chore/ci-workflow` |
+| Research | `research/<slug>` | `research/mcp-audit` |
+
+Always branch from `main`. Push to origin. Open PR against `main`.
+
+---
+
+## PR Conventions
+
+**PR body minimum:**
+```
+Closes #N
+
+<one paragraph: what changed and why>
+```
+
+- Always include `Closes #N` to auto-close the issue on merge
+- No "wip" commits in history — squash before opening
+- One PR per issue; no bundling unrelated changes
+- No direct push to `main` — ever
+
+---
+
+## TDD Workflow (Mandatory)
+
+Every implementation follows Red-Green-Refactor:
+
+1. Write a failing test that describes the behavior
+2. Run it — confirm it fails
+3. Write the minimal code to make it pass
+4. Run tests — confirm pass
+5. Commit
+6. Refactor if needed (tests must still pass)
+
+**Before opening any PR:**
+- [ ] All tests pass locally
+- [ ] No `console.log`, `TODO`, or commented-out code left behind
+- [ ] Every AC from the issue has at least one test
+- [ ] Commit history is clean
+- [ ] No files modified outside the task scope
+
+---
+
+## Task Ownership
+
+`memory/active-tasks.md` (at `/home/georges/.openclaw/workspace/memory/active-tasks.md`) is the single source of truth for who owns what right now.
+
+Format:
+```markdown
+## Active
+- <repo>/<task>: OWNER=<Ren|Forge>, STATUS=<assigned|in-progress|blocked|review>
+```
+
+Forge checks this before acting. If a task is owned by Ren, Forge stands down.
+
+---
+
+## ClickUp Integration
+
+ClickUp (workspace "George Soto's Workspace") tracks project-level work alongside GitHub Issues.
+
+| Tool | Purpose |
+|---|---|
+| GitHub Issues | Code-level: ACs, implementation details, PR tracking |
+| ClickUp | Project-level: priorities, deadlines, blocked items |
+
+Ren manages ClickUp tickets and keeps them in sync with GitHub.
+
+Fish Tank space lists: Backlog, In Progress, Blocked, Done.
+
+---
+
+## CI Requirements
+
+Every repo has `.github/workflows/ci.yml` that runs on every PR and push to `main`:
+- `npm ci` + `npm test` for Next.js repos
+- GUT headless for dungeon-cards (Godot 4)
+
+CI is a required check on all repos — PRs cannot merge if CI fails.
+
+---
+
+## Repo Structure Conventions
+
+Every repo includes:
+- `.devcontainer/devcontainer.json` — Dev container config
+- `.github/workflows/ci.yml` — CI workflow
+- `README.md` — Project overview, setup, architecture
+- Tests in `__tests__/` (Next.js) or `tests/` (GDScript)
+
+---
+
+## Memory Maintenance
+
+At the end of significant sessions, agents write to `memory/YYYY-MM-DD.md`. Periodically, Ren distills daily logs into `MEMORY.md` (long-term memory).
+
+Forge creates `memory/projects/<repo>.md` when working on a repo — stack, routes, DB schema, test setup, gotchas. This file persists between sessions.


### PR DESCRIPTION
Closes #11

**3 new system docs in `docs/`:**

**`system-overview.md`** — Hardware (Pi 5 specs, Tailscale IP), agents (Ren/Forge/Vex workspaces, Discord IDs), GitHub accounts, memory system (L0/L1/L2), autonomous crons, deployed apps

**`agent-guide.md`** — Role descriptions for all 3 agents, what George says to each, the coordination protocol (Vex→Ren→Forge), PR lifecycle, auto-merge rules

**`workflow-guide.md`** — Full task lifecycle (George approval → issue → build → gate → merge), branch naming, PR conventions, TDD checklist, task ownership model, ClickUp dual-track, CI requirements, repo structure conventions

**2 README rewrites:**
- bomb-burritos PR #5 — full rewrite from create-next-app template
- portfolio PR #6 — full rewrite from create-next-app template

**3 existing READMEs (checkout-demo, webhook-inspector, agent-monitor)** — already have architecture sections per the issue; no changes needed.